### PR TITLE
Make default logger null

### DIFF
--- a/Source/Searching/FoodSearch.cs
+++ b/Source/Searching/FoodSearch.cs
@@ -30,7 +30,7 @@ namespace SimpleFoodSelection.Searching
             this.traceOutput = traceOutput;
         }
 
-        private readonly StringBuilder traceOutput = new StringBuilder();
+        private readonly StringBuilder traceOutput = null;
 
         private readonly FoodSearchParameters parameters;
         private readonly FoodSearchGroups foodSearchGroups;


### PR DESCRIPTION
Currently even without a DEBUG tag the logger will log tons of lines per pawn per search. I think it is what drags down perf (if I nulled it, I can run consistently at 24FPS with 90 colonists, 4x, food available or not; when it is initialized, I got like 14 FPS after running at 4x for about 1-3 minutes)